### PR TITLE
Change "Python" to "Python3"

### DIFF
--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -105,7 +105,7 @@ function installPackages {
         autoconf automake autopoint bash bison bzip2 flex gettext\
         g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev \
         libtool libltdl-dev libssl-dev libxml-parser-perl make python3-mako \
-        openssl p7zip-full patch perl pkg-config python ruby scons \
+        openssl p7zip-full patch perl pkg-config python3 ruby scons \
         sed unzip wget xz-utils libtool-bin texinfo g++-multilib lzip -y
 }
 


### PR DESCRIPTION
This fixs the issuse "Python has no installation candidate" 

Ref:
Issue #18 