### PR TITLE
Fix Ubuntu 22.04 issues and add parallelization support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get install -y \
     git \
     wget \
     sudo \
+    make \
+    lsb-release \
   && chmod +x /i686-elf-tools/i686-elf-tools.sh \
   && /i686-elf-tools/i686-elf-tools.sh env \
   && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     make \
     lsb-release \
   && chmod +x /i686-elf-tools/i686-elf-tools.sh \
-  && /i686-elf-tools/i686-elf-tools.sh env \
+  && /i686-elf-tools/i686-elf-tools.sh env -parallel \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /opt/mxe/.ccache \
   && rm -rf /opt/mxe/pkg

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you experience any issues, you can specify one or more command line arguments
 * `-bv`/`--binutils-version` - specify the Binutils version to build
 * `-dv`/`--gdb-version` - specify the GDB version to build
 * `-64` - compile for x86_64-elf instead of i686-elf
-* `-parallel` - support parallel jobs in GNU Make (`-j4` by default)
+* `-parallel` - support parallel jobs in GNU Make (`-j4` by default. Modify the script to override)
 
 ```sh
 # Compile binutils and gcc only

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If you experience any issues, you can specify one or more command line arguments
 * `-bv`/`--binutils-version` - specify the Binutils version to build
 * `-dv`/`--gdb-version` - specify the GDB version to build
 * `-64` - compile for x86_64-elf instead of i686-elf
+* `-parallel` - support parallel jobs in GNU Make (`-j4` by default)
 
 ```sh
 # Compile binutils and gcc only

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you experience any issues, you can specify one or more command line arguments
 * `-bv`/`--binutils-version` - specify the Binutils version to build
 * `-dv`/`--gdb-version` - specify the GDB version to build
 * `-64` - compile for x86_64-elf instead of i686-elf
-* `-parallel` - support parallel jobs in GNU Make (`-j4` by default. Modify the script to override)
+* `-parallel` - build `make` recipes in [parallel](https://www.gnu.org/software/make/manual/html_node/Parallel.html) (`-j4`). To modify the number of jobs executed in parallel, modify `i686-elf-tools.sh`
 
 ```sh
 # Compile binutils and gcc only
@@ -96,6 +96,8 @@ Logs are stored for each stage of the process under *~/build-i686-elf/build-**xy
 e.g. **~/build-i686-elf/build-gcc-7.1.0/gcc_make.log**
 
 If you attempt to run `make` and `configure` commands manually that depend on components of the linux i686-elf toolchain, ensure `~/build-i686-elf/linux/output/bin` is on your path, else you may get errors about binaries being missing.
+
+By default, i686-elf-tools will build `make` recipes in parallel. If any arguments are specified to `i686-elf-tools.sh` however, parallel compilation must be opted into by explicitly specifying `-parallel`.
 
 ## Mac OS X
 

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -310,7 +310,7 @@ function compileBinutils {
         # Make
         echoColor "        Making (binutils_make.log)"
 	    if [[ $PARALLEL == true ]]; then
-            make -j4 >> binutils_make.log
+            	make -j4 >> binutils_make.log
 	    else
 	        make >> binutils_make.log
 	    fi

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -100,52 +100,52 @@ function main {
 }
 function installPackages {
     pkg_list=(
-	git
-	autoconf
-	automake
-	autopoint
-	bash
-	bison
-	bzip2
-	flex
-	gettext
-	g++
-	gperf
-	intltool
-	libffi-dev
-	libgdk-pixbuf2.0-dev
-	libtool
-	libltdl-dev
-	libssl-dev
-	libxml-parser-perl
-	make
-	python3-mako
-	openssl
-	p7zip-full
-	patch
-	perl
-	pkg-config
-	ruby
-	scons
-	sed
-	unzip
-	wget
-	xz-utils
-	libtool-bin
-	texinfo
-	g++-multilib
-	lzip)
+        git
+        autoconf
+        automake
+        autopoint
+        bash
+        bison
+        bzip2
+        flex
+        gettext
+        g++
+        gperf
+        intltool
+        libffi-dev
+        libgdk-pixbuf2.0-dev
+        libtool
+        libltdl-dev
+        libssl-dev
+        libxml-parser-perl
+        make
+        python3-mako
+        openssl
+        p7zip-full
+        patch
+        perl
+        pkg-config
+        ruby
+        scons
+        sed
+        unzip
+        wget
+        xz-utils
+        libtool-bin
+        texinfo
+        g++-multilib
+        lzip)
     echoColor "Installing packages"
 
     # Fix correct python packages on modern Ubuntu versions
     if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ ]]; then
-	pkg_list+=(python3 python-is-python3)
+        pkg_list+=(python3 python-is-python3)
     else
-	pkg_list+=(python)
+        pkg_list+=(python)
     fi
 
     for pkg in ${pkg_list[@]}; do
-	sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install $pkg -y
+        sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install $pkg -y
     done
 }
 
@@ -160,11 +160,11 @@ function installMXE {
         cd /opt
         sudo -E git clone https://github.com/mxe/mxe.git
         cd mxe
-	if [[ $PARALLEL == true ]]; then
-	    sudo make -j4 gcc
-	else
-	    sudo make gcc
-	fi
+        if [[ $PARALLEL == true ]]; then
+            sudo make -j4 gcc
+        else
+            sudo make gcc
+        fi
     else
        echoColor "    MXE is already installed. You'd better make sure that you've previously made MXE's gcc! (/opt/mxe/usr/bin/i686-w64-mingw32.static-gcc)"
     fi
@@ -309,11 +309,11 @@ function compileBinutils {
         
         # Make
         echoColor "        Making (binutils_make.log)"
-	    if [[ $PARALLEL == true ]]; then
-            	make -j4 >> binutils_make.log
-	    else
-	        make >> binutils_make.log
-	    fi
+        if [[ $PARALLEL == true ]]; then
+            make -j4 >> binutils_make.log
+        else
+            make >> binutils_make.log
+        fi
         
         # Install
         echoColor "        Installing (binutils_install.log)"
@@ -356,10 +356,10 @@ function compileGCC {
         
         # Make GCC
         echoColor "        Making gcc (gcc_make.log)"
-	    if [[ $PARALLEL == true ]]; then
+        if [[ $PARALLEL == true ]]; then
             make -j4 all-gcc >> gcc_make.log
-	    else
-	        make all-gcc >> gcc_make.log
+        else
+            make all-gcc >> gcc_make.log
         fi
         
         # Install GCC
@@ -368,11 +368,11 @@ function compileGCC {
         
         # Make libgcc
         echoColor "        Making libgcc (libgcc_make.log)"
-	    if [[ $PARALLEL == true ]]; then
+        if [[ $PARALLEL == true ]]; then
             make -j4 all-target-libgcc >> libgcc_make.log
-	    else
-	        make all-target-libgcc >> libgcc_make.log
-	    fi
+        else
+            make all-target-libgcc >> libgcc_make.log
+        fi
         
         # Install libgcc
         echoColor "        Installing libgcc (libgcc_install.log)"
@@ -425,11 +425,11 @@ function compileGDB {
         
         # Make
         echoColor "        Making (gdb_make.log)"
-	    if [[ $PARALLEL == true ]]; then
+        if [[ $PARALLEL == true ]]; then
             make -j4 >> gdb_make.log
-	    else
-	        make >> gdb_make.log
-	    fi
+        else
+            make >> gdb_make.log
+        fi
         
         # Install
         echoColor "        Installing (gdb_install.log)"

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -21,7 +21,7 @@ if [ $# -eq 0 ]; then
     BUILD_BINUTILS=true
     BUILD_GCC=true
     BUILD_GDB=true
-    ZIP=true   
+    ZIP=true
     args="binutils gcc gdb zip"
 else
     args=$@
@@ -97,24 +97,55 @@ function main {
         
     finalize
 }
-
 function installPackages {
-    
+    pkg_list=(
+	git
+	autoconf
+	automake
+	autopoint
+	bash
+	bison
+	bzip2
+	flex
+	gettext
+	g++
+	gperf
+	intltool
+	libffi-dev
+	libgdk-pixbuf2.0-dev
+	libtool
+	libltdl-dev
+	libssl-dev
+	libxml-parser-perl
+	make
+	python3-mako
+	openssl
+	p7zip-full
+	patch
+	perl
+	pkg-config
+	ruby
+	scons
+	sed
+	unzip
+	wget
+	xz-utils
+	libtool-bin
+	texinfo
+	g++-multilib
+	lzip)
     echoColor "Installing packages"
-    pkg_list="git autoconf automake autopoint bash bison bzip2 flex gettext "\
-        "g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev "\
-        "libtool libltdl-dev libssl-dev libxml-parser-perl make python3-mako "\
-        "openssl p7zip-full patch perl pkg-config ruby scons "\
-        "sed unzip wget xz-utils libtool-bin texinfo g++-multilib lzip"
+
     # Fix correct python packages on modern Ubuntu versions
-    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ ]]
-    then
-	    pkg_list="$pkg_list python3 python-is-python3"
+    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ ]]; then
+	pkg_list+=(python3 python-is-python3)
     else
-	    pkg_list="$pkg_list python"
+	pkg_list+=(python)
     fi
 
-    sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install "$pkg_list" -y
+    for pkg in ${pkg_list[@]}; do
+	sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install $pkg -y
+    done
 }
 
 # MXE

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -22,6 +22,7 @@ if [ $# -eq 0 ]; then
     BUILD_GCC=true
     BUILD_GDB=true
     ZIP=true
+    PARALLEL=true
     args="binutils gcc gdb zip"
 else
     args=$@
@@ -331,7 +332,7 @@ function compileGCC {
         mkdir -p build-gcc-$GCC_VERSION
         cd build-gcc-$GCC_VERSION
         
-        configureArgs="--target=${BUILD_TARGET} --disable-nls --enable-languages=c --without-headers --prefix=$BUILD_DIR/$1/output"
+        configureArgs="--target=${BUILD_TARGET} --disable-nls --enable-languages=c,c++ --without-headers --prefix=$BUILD_DIR/$1/output"
         
         if [ $1 == "windows" ]
         then

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -101,20 +101,20 @@ function main {
 function installPackages {
     
     echoColor "Installing packages"
-    pkg_list=(git autoconf automake autopoint bash bison bzip2 flex gettext \
-        g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev \
-        libtool libltdl-dev libssl-dev libxml-parser-perl make python3-mako \
-        openssl p7zip-full patch perl pkg-config ruby scons \
-        sed unzip wget xz-utils libtool-bin texinfo g++-multilib lzip)
+    pkg_list="git autoconf automake autopoint bash bison bzip2 flex gettext "\
+        "g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev "\
+        "libtool libltdl-dev libssl-dev libxml-parser-perl make python3-mako "\
+        "openssl p7zip-full patch perl pkg-config ruby scons "\
+        "sed unzip wget xz-utils libtool-bin texinfo g++-multilib lzip"
     # Fix correct python packages on modern Ubuntu versions
     if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ ]]
     then
-	    pkg_list=($pkg_list python3 python-is-python3)
+	    pkg_list="$pkg_list python3 python-is-python3"
     else
-	    pkg_list=($pkg_list python)
+	    pkg_list="$pkg_list python"
     fi
 
-    sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install $pkg_list -y
+    sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install "$pkg_list" -y
 }
 
 # MXE

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # i686-elf-tools.sh
-# v1.3.1
+# v1.3.2
 
 # Define Global Variables
 
@@ -21,8 +21,7 @@ if [ $# -eq 0 ]; then
     BUILD_BINUTILS=true
     BUILD_GCC=true
     BUILD_GDB=true
-    ZIP=true
-    
+    ZIP=true   
     args="binutils gcc gdb zip"
 else
     args=$@
@@ -41,6 +40,7 @@ case $key in
     zip)                    ZIP=true;              ALL_PRODUCTS=false; shift ;;
     env)                    ENV_ONLY=true;                             shift ;;
     -64)                    x64=true;                                  shift ;;
+    -parallel)              PARALLEL=true;                             shift ;;
     -bv|--binutils-version) BINUTILS_VERSION="$2";                     shift; shift ;;
     -gv|--gcc-version)      GCC_VERSION="$2";                          shift; shift ;;
     -dv|--gdb-version)      GDB_VERSION="$2";                          shift; shift ;;
@@ -69,6 +69,7 @@ echo "BINUTILS_VERSION = ${BINUTILS_VERSION}"
 echo "GCC_VERSION      = ${GCC_VERSION}"
 echo "GDB_VERSION      = ${GDB_VERSION}"
 echo "PATH             = ${PATH}"
+echo "PARALLEL         = ${PARALLEL}"
 
 function main {
 
@@ -100,17 +101,23 @@ function main {
 function installPackages {
     
     echoColor "Installing packages"
-
-    sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install git \
-        autoconf automake autopoint bash bison bzip2 flex gettext\
+    pkg_list=(git autoconf automake autopoint bash bison bzip2 flex gettext \
         g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev \
         libtool libltdl-dev libssl-dev libxml-parser-perl make python3-mako \
-        openssl p7zip-full patch perl pkg-config python ruby scons \
-        sed unzip wget xz-utils libtool-bin texinfo g++-multilib lzip -y
+        openssl p7zip-full patch perl pkg-config ruby scons \
+        sed unzip wget xz-utils libtool-bin texinfo g++-multilib lzip)
+    # Fix correct python packages on modern Ubuntu versions
+    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ ]]
+    then
+	    pkg_list=($pkg_list python3 python-is-python3)
+    else
+	    pkg_list=($pkg_list python)
+    fi
+
+    sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install $pkg_list -y
 }
 
 # MXE
-
 function installMXE {
 
     echoColor "Installing MXE"
@@ -121,7 +128,11 @@ function installMXE {
         cd /opt
         sudo -E git clone https://github.com/mxe/mxe.git
         cd mxe
-        sudo make gcc
+	if [[ $PARALLEL == true ]]; then
+	    sudo make -j4 gcc
+	else
+	    sudo make gcc
+	fi
     else
        echoColor "    MXE is already installed. You'd better make sure that you've previously made MXE's gcc! (/opt/mxe/usr/bin/i686-w64-mingw32.static-gcc)"
     fi
@@ -266,7 +277,11 @@ function compileBinutils {
         
         # Make
         echoColor "        Making (binutils_make.log)"
-        make >> binutils_make.log
+	    if [[ $PARALLEL == true ]]; then
+            make -j4 >> binutils_make.log
+	    else
+	        make >> binutils_make.log
+	    fi
         
         # Install
         echoColor "        Installing (binutils_install.log)"
@@ -285,7 +300,7 @@ function compileGCC {
         mkdir -p build-gcc-$GCC_VERSION
         cd build-gcc-$GCC_VERSION
         
-        configureArgs="--target=${BUILD_TARGET} --disable-nls --enable-languages=c,c++ --without-headers --prefix=$BUILD_DIR/$1/output"
+        configureArgs="--target=${BUILD_TARGET} --disable-nls --enable-languages=c --without-headers --prefix=$BUILD_DIR/$1/output"
         
         if [ $1 == "windows" ]
         then
@@ -309,7 +324,11 @@ function compileGCC {
         
         # Make GCC
         echoColor "        Making gcc (gcc_make.log)"
-        make all-gcc >> gcc_make.log
+	    if [[ $PARALLEL == true ]]; then
+            make -j4 all-gcc >> gcc_make.log
+	    else
+	        make all-gcc >> gcc_make.log
+        fi
         
         # Install GCC
         echoColor "        Installing gcc (gcc_install.log)"
@@ -317,7 +336,11 @@ function compileGCC {
         
         # Make libgcc
         echoColor "        Making libgcc (libgcc_make.log)"
-        make all-target-libgcc >> libgcc_make.log
+	    if [[ $PARALLEL == true ]]; then
+            make -j4 all-target-libgcc >> libgcc_make.log
+	    else
+	        make all-target-libgcc >> libgcc_make.log
+	    fi
         
         # Install libgcc
         echoColor "        Installing libgcc (libgcc_install.log)"
@@ -370,7 +393,11 @@ function compileGDB {
         
         # Make
         echoColor "        Making (gdb_make.log)"
-        make >> gdb_make.log
+	    if [[ $PARALLEL == true ]]; then
+            make -j4 >> gdb_make.log
+	    else
+	        make >> gdb_make.log
+	    fi
         
         # Install
         echoColor "        Installing (gdb_install.log)"

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -99,7 +99,7 @@ function main {
     finalize
 }
 function installPackages {
-    pkg_list=(
+    pkgList=(
         git
         autoconf
         automake
@@ -139,12 +139,12 @@ function installPackages {
 
     # Fix correct python packages on modern Ubuntu versions
     if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ ]]; then
-        pkg_list+=(python3 python-is-python3)
+        pkgList+=(python3 python-is-python3)
     else
-        pkg_list+=(python)
+        pkgList+=(python)
     fi
 
-    for pkg in ${pkg_list[@]}; do
+    for pkg in ${pkgList[@]}; do
         sudo -E DEBIAN_FRONTEND=noninteractive apt-get -qq install $pkg -y
     done
 }


### PR DESCRIPTION
- Fixed python3 issues under Ubuntu 22.04.
- Added support for parallelization with GNU Make builds (`-j4` by default).

Total build take ~12 minutes with parallelization on an i7-6700K.