### PR TITLE
Added support to cross-compile gnu-efi

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: truexpixels/i686-elf-tools
+          images: lordmilko/i686-elf-tools
           tags: |
             type=raw,value=latest
       

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: lordmilko/i686-elf-tools
+          images: truexpixels/i686-elf-tools
           tags: |
             type=raw,value=latest
       

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -75,8 +75,9 @@ echo "PARALLEL         = ${PARALLEL}"
 function main {
 
     installPackages
+if [[ $WINDOWS_ONLY == true ]]; then
     installMXE
-    
+fi
     if [[ $ENV_ONLY == true ]]; then
         echoColor "Successfully installed build environment. Exiting as 'env' only was specified"
         return
@@ -298,6 +299,9 @@ function compileBinutils {
         cd build-binutils-$BINUTILS_VERSION
         
         configureArgs="--target=${BUILD_TARGET} --with-sysroot --disable-nls --disable-werror --prefix=$BUILD_DIR/$1/output"
+	    if [[ $x64 == true ]]; then
+	       configureArgs="--enable-targets=x86_64-pep $configureArgs"
+	    fi
         
         if [ $1 == "windows" ]
         then


### PR DESCRIPTION
(eng isnt my native language sorry)
sorry im again but i promise i will never come after this

i need this for compile gnu-efi plz

i added efi support to binutils

without efi support:
x86_64-elf-objcopy: (some file name): invalid bfd target

with efi support: (passes)

and this is only for x86_64, i cant found ia32 relevant

[click to see all binutils bfd targets](https://github.com/bminor/binutils-gdb/blob/master/bfd/config.bfd)

[x] Build, Tested successfully on WSL

also thanks for making github actions ❤️

i added windows only in installMXE because we dont need mxe in linux builds (if you dont liked it, u can remove)