### PR TITLE
Fix Ubuntu-based distros not being detected and failing to install packages

### DIFF
--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -139,7 +139,7 @@ function installPackages {
     echoColor "Installing packages"
 
     # Fix correct python packages on modern Ubuntu versions
-    source /etc/os-release # Zorin OS doesn't use lsb_release, but rather uses $ID_LIKE
+    source /etc/os-release || true # Zorin OS doesn't use lsb_release, but rather uses $ID_LIKE
     if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ || $ID_LIKE =~ "ubuntu" ]]; then
         pkgList+=(python3 python-is-python3)
     else

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -139,7 +139,8 @@ function installPackages {
     echoColor "Installing packages"
 
     # Fix correct python packages on modern Ubuntu versions
-    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ ]]; then
+    source /etc/os-release # Zorin OS doesn't use lsb_release, but rather uses $ID_LIKE
+    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ || $ID_LIKE =~ "ubuntu" ]]; then
         pkgList+=(python3 python-is-python3)
     else
         pkgList+=(python)


### PR DESCRIPTION
Tested on Zorin OS, which doesn't put Ubuntu codename in lsb_release - this PR uses both the `lsb_release -a` method and by sourcing `/etc/os-release` and checking $ID_LIKE.

I do not have access to an Ubuntu-based or any other testing machine so if someone could check it that would be very nice :)

Hope this helps!