### PR TITLE
Fix Python package errors

### DIFF
--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -138,9 +138,8 @@ function installPackages {
         lzip)
     echoColor "Installing packages"
 
-    # Fix correct python packages on modern Ubuntu versions
-    source /etc/os-release || true # Zorin OS doesn't use lsb_release, but rather uses $ID_LIKE
-    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ || $ID_LIKE =~ "ubuntu" ]]; then
+    # Fix correct python packages on modern Ubuntu and Ubuntu-based distros
+    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ || $(cat /etc/os-release) =~ .*(U|u)buntu.*$ || $(apt-cache search --names-only ^python$ | wc -m) -gt 0 ]]; then
         pkgList+=(python3 python-is-python3)
     else
         pkgList+=(python)

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -139,7 +139,7 @@ function installPackages {
     echoColor "Installing packages"
 
     # Fix correct python packages on modern Ubuntu versions
-    source /etc/os-release # Zorin OS doesn't use lsb_release, but rather uses $ID_LIKE
+    source /etc/os-release || true # Zorin OS doesn't use lsb_release, but rather uses $ID_LIKE
     if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ || $ID_LIKE =~ "ubuntu" ]]; then
         pkgList+=(python3 python-is-python3)
     else

--- a/i686-elf-tools.sh
+++ b/i686-elf-tools.sh
@@ -139,7 +139,8 @@ function installPackages {
     echoColor "Installing packages"
 
     # Fix correct python packages on modern Ubuntu versions
-    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ ]]; then
+    source /etc/os-release # Zorin OS doesn't use lsb_release, but rather uses $ID_LIKE
+    if [[ $(lsb_release -a) =~ .*"Ubuntu".*$ || $ID_LIKE =~ "ubuntu" ]]; then
         pkgList+=(python3 python-is-python3)
     else
         pkgList+=(python)


### PR DESCRIPTION
Long time no see :)

This is a redone patch for the "python has no installation candidate" error.

It uses both the original `lsb_release -a` method, but also will `cat /etc/os-release` and will check the package cache via `apt-cache` (both suggested by @NotYourFox in #28).\
These methods work fine on my test bench of Zorin OS 17.2 and should work on any other Ubuntu-based distro like Linux Mint.

 **NOTE:** It might actually be better to switch the cases around (if not detecting python3, then install python). Most modern distros separate the packages into `python3` and `python2` - meaning only an `apt-cache` or `apt search` command would be necessary. If this is better I can draft this PR and make the changes.